### PR TITLE
Make clear that app labels are a Docker construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package tails the Docker event stream for container events and performs spe
 - Container restarts that result in IP address changes will result in call to `dokku nginx:build-config` for the related app.
 - Container restarts that exceed the maximum restart policy retry count for the given container will result in a call to `dokku ps:rebuild` for the related app.
 
-Note that this is only performed for Dokku app containers with the label `com.dokku.app-name`. If the container is missing that label, then no action will be performed when that container emits events on the Docker event stream.
+Note that this is only performed for Dokku app containers with the docker label `com.dokku.app-name`. If the container is missing that label, then no action will be performed when that container emits events on the Docker event stream. Use `docker inspect <container>` to verify see [Docker object labels](https://docs.docker.com/config/labels-custom-metadata/).
 
 ## Installation
 


### PR DESCRIPTION
Make clear that app labels are a Docker construct and show how to verify that the expected label has been applied by dokku.

ref https://github.com/dokku/dokku/issues/3152