### PR TITLE
Remove support for armhf, Ubuntu Bionic, and Debian Buster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   hadolint:
     name: hadolint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
 
   markdown-lint:
     name: markdown-lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
 
   shellcheck:
     name: shellcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
           SHELLCHECK_OPTS: -s bash
   shfmt:
     name: shfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
 
   yamllint:
     name: yamllint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-buster
+FROM golang:1.20.5-bookworm
 
 # hadolint ignore=DL3027
 RUN apt-get update \
@@ -9,6 +9,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # hadolint ignore=DL3028
-RUN gem install --no-ri --no-rdoc --quiet rake fpm package_cloud
+RUN gem install --quiet rake fpm package_cloud
 
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,8 @@ build: prebuild
 	@$(MAKE) build/darwin/$(NAME)
 	@$(MAKE) build/linux/$(NAME)-amd64
 	@$(MAKE) build/linux/$(NAME)-arm64
-	@$(MAKE) build/linux/$(NAME)-armhf
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_arm64.deb
-	@$(MAKE) build/deb/$(NAME)_$(VERSION)_armhf.deb
 
 build-docker-image:
 	docker build --rm -q -f Dockerfile -t $(IMAGE_NAME):build .
@@ -79,12 +77,6 @@ build/linux/$(NAME)-arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
 										-ldflags "-s -w -X main.Version=$(VERSION)" \
 										-o build/linux/$(NAME)-arm64
-
-build/linux/$(NAME)-armhf:
-	mkdir -p build/linux
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=5 go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
-										-ldflags "-s -w -X main.Version=$(VERSION)" \
-										-o build/linux/$(NAME)-armhf
 
 build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)-amd64
 	export SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct) \
@@ -132,29 +124,6 @@ build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
 		install/systemd.target=/etc/systemd/system/$(NAME).target \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
-build/deb/$(NAME)_$(VERSION)_armhf.deb: build/linux/$(NAME)-armhf
-	export SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct) \
-		&& mkdir -p build/deb \
-		&& fpm \
-		--after-install install/postinstall.sh \
-		--architecture armhf \
-		--category utils \
-		--description "$$PACKAGE_DESCRIPTION" \
-		--input-type dir \
-		--license 'MIT License' \
-		--maintainer "$(MAINTAINER_NAME) <$(EMAIL)>" \
-		--name $(NAME) \
-		--output-type deb \
-		--package build/deb/$(NAME)_$(VERSION)_armhf.deb \
-		--url "https://github.com/$(MAINTAINER)/$(REPOSITORY)" \
-		--vendor "" \
-		--version $(VERSION) \
-		--verbose \
-		build/linux/$(NAME)-armhf=/usr/bin/$(NAME) \
-		install/systemd.service=/etc/systemd/system/$(NAME).service \
-		install/systemd.target=/etc/systemd/system/$(NAME).target \
-		LICENSE=/usr/share/doc/$(NAME)/copyright
-
 clean:
 	rm -rf build release validation
 
@@ -181,51 +150,38 @@ release: build bin/gh-release bin/gh-release-body
 	rm -rf release && mkdir release
 	tar -zcf release/$(NAME)_$(VERSION)_linux_amd64.tgz -C build/linux $(NAME)-amd64
 	tar -zcf release/$(NAME)_$(VERSION)_linux_arm64.tgz -C build/linux $(NAME)-arm64
-	tar -zcf release/$(NAME)_$(VERSION)_linux_armhf.tgz -C build/linux $(NAME)-armhf
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_$(HARDWARE).tgz -C build/darwin $(NAME)
 	cp build/deb/$(NAME)_$(VERSION)_amd64.deb release/$(NAME)_$(VERSION)_amd64.deb
 	cp build/deb/$(NAME)_$(VERSION)_arm64.deb release/$(NAME)_$(VERSION)_arm64.deb
-	cp build/deb/$(NAME)_$(VERSION)_armhf.deb release/$(NAME)_$(VERSION)_armhf.deb
 	bin/gh-release create $(MAINTAINER)/$(REPOSITORY) $(VERSION) $(shell git rev-parse --abbrev-ref HEAD)
 	bin/gh-release-body $(MAINTAINER)/$(REPOSITORY) v$(VERSION)
 
 release-packagecloud:
 	@$(MAKE) release-packagecloud-deb
 
-release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAME)_$(VERSION)_arm64.deb build/deb/$(NAME)_$(VERSION)_armhf.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/bionic  build/deb/$(NAME)_$(VERSION)_amd64.deb
+release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal   build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy   build/deb/$(NAME)_$(VERSION)_amd64.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/buster  build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal    build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy    build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_arm64.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal    build/deb/$(NAME)_$(VERSION)_armhf.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy    build/deb/$(NAME)_$(VERSION)_armhf.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/buster build/deb/$(NAME)_$(VERSION)_armhf.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/bullseye build/deb/$(NAME)_$(VERSION)_armhf.deb
 
 validate:
 	mkdir -p validation
 	lintian build/deb/$(NAME)_$(VERSION)_amd64.deb || true
 	lintian build/deb/$(NAME)_$(VERSION)_arm64.deb || true
-	lintian build/deb/$(NAME)_$(VERSION)_armhf.deb || true
 	dpkg-deb --info build/deb/$(NAME)_$(VERSION)_amd64.deb
 	dpkg-deb --info build/deb/$(NAME)_$(VERSION)_arm64.deb
-	dpkg-deb --info build/deb/$(NAME)_$(VERSION)_armhf.deb
 	dpkg -c build/deb/$(NAME)_$(VERSION)_amd64.deb
 	dpkg -c build/deb/$(NAME)_$(VERSION)_arm64.deb
-	dpkg -c build/deb/$(NAME)_$(VERSION)_armhf.deb
 	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_amd64.deb
 	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_arm64.deb
-	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_armhf.deb
 	ls -lah build/deb validation
 	sha1sum build/deb/$(NAME)_$(VERSION)_amd64.deb
 	sha1sum build/deb/$(NAME)_$(VERSION)_arm64.deb
-	sha1sum build/deb/$(NAME)_$(VERSION)_armhf.deb
 
 prebuild:
 	git config --global --add safe.directory $(shell pwd)


### PR DESCRIPTION
These platforms are no longer supported.

Also update the github actions runner.