### PR TITLE
fix: avoid ps:rebuild loop with always restart policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,16 @@ jobs:
           name: build
           path: build/**/*
 
+  test:
+    name: test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test ./...
+
   binary-check:
     name: binary-check
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ version:
 	@echo "$(CI_BRANCH)"
 	@echo "$(VERSION)"
 
+test:
+	go test ./...
+
 define PACKAGE_DESCRIPTION
 Service that listens to docker events and runs dokku commands
 endef

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Service that listens to docker events and runs dokku commands.
 This package tails the Docker event stream for container events and performs specific actions depending on those events.
 
 - Container restarts that result in IP address changes will result in call to `dokku nginx:build-config` for the related app.
-- Container restarts that exceed the maximum restart policy retry count for the given container will result in a call to `dokku ps:rebuild` for the related app.
+- Containers using the `on-failure` restart policy that die after exhausting their maximum restart retry count will result in a call to `dokku ps:rebuild` for the related app. Containers using the `always` or `unless-stopped` restart policies are restarted by Docker itself and are never rebuilt, avoiding an infinite rebuild loop.
 
 Note that this is only performed for Dokku app containers with the docker label `com.dokku.app-name`. If the container is missing that label, then no action will be performed when that container emits events on the Docker event stream. Use `docker inspect <container>` to verify see [Docker object labels](https://docs.docker.com/config/labels-custom-metadata/).
 

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -262,6 +262,19 @@ func watchEvents(ctx context.Context, sinceTimestamp *int64) error {
 	}
 }
 
+// shouldRebuildOnDie reports whether a container's "die" event means Docker has
+// permanently given up restarting it, so the app should be rebuilt. This only
+// happens with the "on-failure" restart policy once the restart count reaches a
+// positive maximum retry count. Containers using "always"/"unless-stopped" are
+// restarted by Docker indefinitely and "no" containers are never restarted, so
+// rebuilding them here would create an infinite loop: their MaximumRetryCount is
+// always 0, which matches the RestartCount of a freshly created replacement.
+func shouldRebuildOnDie(restartPolicy container.RestartPolicy, restartCount int) bool {
+	return restartPolicy.IsOnFailure() &&
+		restartPolicy.MaximumRetryCount > 0 &&
+		restartCount >= restartPolicy.MaximumRetryCount
+}
+
 func handleEvent(ctx context.Context, event events.Message) error {
 	containerId := event.Actor.ID
 	containerShortId := containerId[0:9]
@@ -286,17 +299,14 @@ func handleEvent(ctx context.Context, event events.Message) error {
 	appName := container.Config.Labels[DOKKU_APP_LABEL]
 
 	if event.Action == "die" {
-		if container.HostConfig.RestartPolicy.Name == "no" {
-			return nil
-		}
-
-		if container.RestartCount == container.HostConfig.RestartPolicy.MaximumRetryCount {
+		restartPolicy := container.HostConfig.RestartPolicy
+		if shouldRebuildOnDie(restartPolicy, container.RestartCount) {
 			log.Info().
 				Str("container_id", containerShortId).
 				Str("app", appName).
-				Str("restart_policy", string(container.HostConfig.RestartPolicy.Name)).
+				Str("restart_policy", string(restartPolicy.Name)).
 				Int("restart_count", container.RestartCount).
-				Int("max_restart_count", container.HostConfig.RestartPolicy.MaximumRetryCount).
+				Int("max_restart_count", restartPolicy.MaximumRetryCount).
 				Msg("rebuilding_app")
 			if err := runCommand("dokku", "--quiet", "ps:rebuild", appName); err != nil {
 				log.Warn().
@@ -307,6 +317,8 @@ func handleEvent(ctx context.Context, event events.Message) error {
 				return err
 			}
 		}
+
+		return nil
 	}
 
 	// skip non-start events

--- a/commands/watch_test.go
+++ b/commands/watch_test.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+func TestShouldRebuildOnDie(t *testing.T) {
+	tests := []struct {
+		name         string
+		policy       container.RestartPolicyMode
+		restartCount int
+		maxRetry     int
+		want         bool
+	}{
+		{
+			name:         "always never rebuilds (reported bug)",
+			policy:       container.RestartPolicyAlways,
+			restartCount: 0,
+			maxRetry:     0,
+			want:         false,
+		},
+		{
+			name:         "always never rebuilds with restart count",
+			policy:       container.RestartPolicyAlways,
+			restartCount: 5,
+			maxRetry:     0,
+			want:         false,
+		},
+		{
+			name:         "unless-stopped never rebuilds",
+			policy:       container.RestartPolicyUnlessStopped,
+			restartCount: 0,
+			maxRetry:     0,
+			want:         false,
+		},
+		{
+			name:         "no policy never rebuilds",
+			policy:       container.RestartPolicyDisabled,
+			restartCount: 0,
+			maxRetry:     0,
+			want:         false,
+		},
+		{
+			name:         "empty policy never rebuilds",
+			policy:       "",
+			restartCount: 0,
+			maxRetry:     0,
+			want:         false,
+		},
+		{
+			name:         "on-failure with unlimited retries never rebuilds",
+			policy:       container.RestartPolicyOnFailure,
+			restartCount: 0,
+			maxRetry:     0,
+			want:         false,
+		},
+		{
+			name:         "on-failure not yet exhausted does not rebuild",
+			policy:       container.RestartPolicyOnFailure,
+			restartCount: 5,
+			maxRetry:     10,
+			want:         false,
+		},
+		{
+			name:         "on-failure one short does not rebuild",
+			policy:       container.RestartPolicyOnFailure,
+			restartCount: 9,
+			maxRetry:     10,
+			want:         false,
+		},
+		{
+			name:         "on-failure exhausted rebuilds",
+			policy:       container.RestartPolicyOnFailure,
+			restartCount: 10,
+			maxRetry:     10,
+			want:         true,
+		},
+		{
+			name:         "on-failure exceeded rebuilds",
+			policy:       container.RestartPolicyOnFailure,
+			restartCount: 11,
+			maxRetry:     10,
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restartPolicy := container.RestartPolicy{
+				Name:              tt.policy,
+				MaximumRetryCount: tt.maxRetry,
+			}
+			if got := shouldRebuildOnDie(restartPolicy, tt.restartCount); got != tt.want {
+				t.Errorf("shouldRebuildOnDie(%+v, %d) = %v, want %v", restartPolicy, tt.restartCount, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Setting `dokku ps:set --global restart-policy always` caused some apps to get stuck rebuilding again and again. Containers using the `always` or `unless-stopped` restart policy always report a `MaximumRetryCount` of 0, which matched the `RestartCount` of a freshly created container, so every `die` event satisfied the rebuild condition. Because `ps:rebuild` stops the old container, it emitted another `die` event, triggering yet another rebuild in an infinite loop.

Rebuilds on a `die` event are now limited to the `on-failure` policy once its positive maximum retry count has been exhausted, the only case where Docker permanently gives up restarting a container. Containers using `always` or `unless-stopped` are restarted by Docker itself and are left alone, and `no` containers are never restarted.

Closes #425.
