### PR TITLE
chore(deps): bump json from 2.15.2.1 to 2.21.2 in /.github

### DIFF
--- a/.github/Gemfile.lock
+++ b/.github/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     http-cookie (1.1.0)
       domain_name (~> 0.5)
     insist (1.0.0)
-    json (2.15.2.1)
+    json (2.21.2)
     logger (1.7.0)
     mime-types (3.7.0)
       logger


### PR DESCRIPTION
Bumps the `json` gem in `.github/Gemfile.lock` from `2.15.2.1` to `2.21.2` to resolve Dependabot security alert #60 (GHSA-x2f5-4prf-w687 / CVE-2026-54696).

Versions of `json` in the range `>= 2.9.0, < 2.19.9` contain a heap out-of-bounds write in the IO-streaming generator path (`JSON.dump(obj, io)` and `JSON::State#generate(obj, io)`). A remote attacker who controls a string field near 16 KB that an application serializes through the IO path can trigger the overflow, resulting in a reliable process crash (denial of service). The vulnerability was first patched in `2.19.9`, and this change updates to the current `2.21.2` release.

Here `json` is an indirect dependency of `package_cloud`, which is used only by the tagged-release workflow to build and publish `.deb` packages during CI. It is not part of the Go application runtime. The gem declares no runtime dependencies and continues to satisfy `package_cloud`'s `~> 2.9` constraint, so this is an isolated lock-file update with no cascading changes.
